### PR TITLE
fix: ペイルド社の社名変更に追従

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 - ドライブレコーダーで動作するDeep LearningやComputer Visionを含むシステムの開発言語として採用しています
 - [エッジMLシステムをC/C++からRustへ移行した事例](https://docs.google.com/presentation/d/1HOL9jheJnKkh2q7w3hU_px-je1qL7lxrSXV-0P1hces/)
 
-### [株式会社Handii](https://www.handii.co.jp/)
+### [株式会社ペイルド](https://www.paild.co.jp/)
 
 - Handiiの運営する法人向けウォレットサービス[paild](https://www.paild.io/)のサーバーサイドの開発言語として利用しています。
 - Webframeworkはactix-webを利用中。


### PR DESCRIPTION
株式会社Handiiは2022年8月1日付で株式会社ペイルドに社名変更をしたので追従しました。